### PR TITLE
Fixed name of action in metadata file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'TJ Cappelletti'
+name: 'Add NuGet Registries'
 description: 'Allows you to add one or more NuGet registries that require authentication safely and securely.'
 author: 'Webstorm Technologies'
 inputs:


### PR DESCRIPTION
This pull request includes a single change to the `action.yml` file, where the `name` field was modified to provide a more descriptive name for the action.

Main change:

* <a href="diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R1">`action.yml`</a>: Modified the `name` field to provide a more descriptive name for the action.