### PR TITLE
Fix: Added missing URL to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The JSON to add this source via the action would look like this:
   {
     "name":"internal",
     "password":"P@$$w0rd",
-    "url":"",
+    "url":"https://nuget.myfeed.local",
     "username":"nuget-user"
   }
 ]


### PR DESCRIPTION
This pull request updates the URL for a JSON source in the `README.md` file to "https://nuget.myfeed.local" in order to add the source via an action.

Main change:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R60">`README.md`</a>: Updated the URL for a JSON source in the `README.md` file to "https://nuget.myfeed.local" in order to add the source via an action.