### PR TITLE
Tag Repo with Version

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -10,7 +10,7 @@ jobs:
     name: Generate Semantic Version
     uses: webstorm-tech/workflows/.github/workflows/gitversion-workflow.yml@v5
 
-  tagRepoMajorJob:
+  tagRepoJob:
     name: Tag Repo with Versions
     needs: [gitVersionJob]
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -10,10 +10,88 @@ jobs:
     name: Generate Semantic Version
     uses: webstorm-tech/workflows/.github/workflows/gitversion-workflow.yml@v5
 
-  tagRepoJob:
-    name: Create GitHub Tag
-    needs: gitVersionJob
-    uses: webstorm-tech/workflows/.github/workflows/github-tag-repo-workflow.yml@v5
-    with:
-      semVer: ${{ needs.gitVersionJob.outputs.semVer }}
-    secrets: inherit
+  tagRepoMajorJob:
+    name: Tag Repo with Versions
+    needs: [gitVersionJob]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create tag
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // *********************************************** \\
+            // Create SemVer Tag                               \\
+            // *********************************************** \\
+            console.log("Creating the v${{ needs.gitVersionJob.outputs.semVer }} tag...")
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.semVer }}',
+              sha: context.sha
+            })
+
+            console.log("Creating the v${{ needs.gitVersionJob.outputs.major }} tag...")
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.major }}',
+              sha: context.sha
+            })
+
+            // *********************************************** \\
+            // Create Major/Minor Tag                          \\
+            // *********************************************** \\
+            try {
+              console.log("Chekcing if v${{ needs.gitVersionJob.outputs.majorMinor }} tag exists...")
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/v${{ needs.gitVersionJob.outputs.majorMinor }}'
+              })
+
+              console.log("Deleteing the v${{ needs.gitVersionJob.outputs.majorMinor }} tag...")
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/v${{ needs.gitVersionJob.outputs.majorMinor }}'
+              })
+            } catch (error) {
+              if (error.status === 404) {
+                console.log("The v${{ needs.gitVersionJob.outputs.majorMinor }} tag does not exist...")
+              } else {
+                throw error;
+              }
+            }
+
+            console.log("Creating the v${{ needs.gitVersionJob.outputs.majorMinor }} tag...")
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ needs.gitVersionJob.outputs.majorMinor }}',
+              sha: context.sha
+            })
+
+            // *********************************************** \\
+            // Create Major Tag                                \\
+            // *********************************************** \\
+            try {
+              console.log("Chekcing if v${{ needs.gitVersionJob.outputs.major }} tag exists...")
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/v${{ needs.gitVersionJob.outputs.major }}'
+              })
+
+              console.log("Deleteing the v${{ needs.gitVersionJob.outputs.major }} tag...")
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/v${{ needs.gitVersionJob.outputs.major }}'
+              })
+            } catch (error) {
+              if (error.status === 404) {
+                console.log("The v${{ needs.gitVersionJob.outputs.major }} tag does not exist...")
+              } else {
+                throw error;
+              }
+            }


### PR DESCRIPTION
## Summary
This updates the `tagRepoJob` so that it tags the repo with `v[major]`, `v[major].[minor]`, and `v[major].[minor].[patch]` formats. This allows consumers to determine how they wish get updates. They can pin to the major, major and minor, or the full sematic versioning. This will require strict adherence to the semantic versioning guidance as documented at https://semver.org/.

* `.github/workflows/continuous-delivery.yml`: Implements changes related to continuous delivery. (`.github/workflows/continuous-delivery.yml`)